### PR TITLE
fix typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The `callback` should receive (err, action, data) - error, same action and resol
 
 ## Transports
 
-Madrill, SendGrid, MailGun, Twillio etc..
+Mandrill, SendGrid, MailGun, Twillio etc..
 
 TDB.
 


### PR DESCRIPTION
Madrill -> Mandrill
